### PR TITLE
Added Support for result export to JSON file

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ func main() {
 	urlFileFlag := flag.String("f", "", "(file) takes in file name containing list of shortened URLs")
 	helpFlag := flag.Bool("h", false, "(help) prints help menu")
 	excludeFlag := flag.String("ex", "", "(exclude) takes in comma seperated response code(403,404,...etc) as input and excludes the result corresponding to those response code")
+	outputFileExtFlag := flag.Bool("j", false, "(output file extension) true if you want it to save in json file else the result will be saved in a text file")
+
 	flag.Parse()
 
 	sessionConfig := config{}
@@ -66,10 +68,24 @@ func main() {
 
 	//TODO: add support to export in JSON,CSV and other
 	//after all the process is done
-	if len(*outputFileFlag) == 0 {
-		//generate one with name: date_time.txt
-		*outputFileFlag = "./output/" + time.Now().Format("01-02-2006_15:04:05") + ".txt"
+
+	// Type of file
+	fileExt := ".txt" // default value
+	/* Check if the FileExtFlag is true,
+	If it is then the fileExt value will be json else it will be default .txt */
+	if *outputFileExtFlag {
+		fileExt = ".json"
 	}
+	if len(*outputFileFlag) == 0 {
+		*outputFileFlag = "./output/" + time.Now().Format("01-02-2006_15:04:05") + fileExt
+	} else {
+		// If Json FileName is given as input
+		fileNameArr := strings.Split(*outputFileFlag, ".")
+		if fileNameArr[1] == "json" {
+			fileExt = ".json"
+		}
+	}
+
 	sessionConfig.outputFile = *outputFileFlag
 
 	sessionConfig.display()
@@ -85,9 +101,17 @@ func main() {
 	wg.Wait()
 
 	fmt.Printf("\n[*] Done")
-	fmt.Printf("\n[*] Saving results to file: %s\n", *outputFileFlag)
+	/*
+		if the fileExt is .txt, then call WriteToTextFile
+		else check whether the fileExt is .json, if it's true then call WriteToJsonFile
+	*/
+	fmt.Printf("\n[*] Saving results to text file: %s\n", *outputFileFlag)
+	if fileExt == ".txt" {
+		utils.WriteToTextFile(sessionConfig.resultList, *outputFileFlag)
+	} else if fileExt == ".json" {
+		utils.WriteToJsonFile(sessionConfig.resultList, *outputFileFlag)
+	}
 
-	utils.WriteToFile(sessionConfig.resultList, *outputFileFlag)
 	fmt.Printf("[*] Saved\n")
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -49,6 +51,13 @@ Example:
 `
 	fmt.Println(banner)
 	os.Exit(0)
+}
+
+// Json Format keys of how the data will be shown in json file
+type jsonFormat struct {
+	StatusCode  string
+	ShortUrl    string
+	OriginalUrl string
 }
 
 //check error
@@ -108,7 +117,7 @@ func GetStdin() []string {
 }
 
 //writes slice of string line by line to a file
-func WriteToFile(resList []string, filePath string) {
+func WriteToTextFile(resList []string, filePath string) {
 	//if file doesn't exists then create one
 	outFile, err := os.Create(filePath)
 	CheckErr(err)
@@ -118,6 +127,27 @@ func WriteToFile(resList []string, filePath string) {
 	}
 	writer.Flush()
 	outFile.Close()
+}
+
+// Write to JSON File at once
+func WriteToJsonFile(resList []string, filePath string) {
+	// Array to store the struct object
+	var jsonArr []jsonFormat
+	// Iterating over the string Array
+	for _, u := range resList {
+		// Splitting the string with space to separate words
+		testArray := strings.Fields(u)
+		// Creating object of jsonFormat struct
+		elements := jsonFormat{
+			testArray[0],
+			testArray[1],
+			testArray[2],
+		}
+		jsonArr = append(jsonArr, elements)
+	}
+	f, _ := json.MarshalIndent(jsonArr, "", "  ")
+	// Writing to Json File
+	_ = ioutil.WriteFile(filePath, f, 0644)
 }
 
 //return unshortened URL


### PR DESCRIPTION
Fixes : #2 

I have added a new function in `utils.go` file `WriteToJsonFile` & correspondingly added `-j` flag if the user wants to export the data to `json` file else the data will be exported to a `text` file . 
If the user enter's the file to which he wants to export , it will check entered file name's extension , if it is `.json` it will call `WriteToJsonFile` method else `WriteToTextFile` is called.



https://user-images.githubusercontent.com/44670961/136663334-74a0a7d2-02f2-48c9-91d7-4e07c8dee8d7.mp4


